### PR TITLE
Added the logger dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Added the logger dependency, see: https://bit.ly/3E8Zqg0 (#7)
 
 ### 1.4.1 (13 January 2025)
 

--- a/lib/countless.rb
+++ b/lib/countless.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'zeitwerk'
+require 'logger'
 require 'active_support'
 require 'active_support/concern'
 require 'active_support/core_ext/module/delegation'


### PR DESCRIPTION
```
NameError: uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
/home/runner/work/fake-data/fake-data/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>'
/home/runner/work/fake-data/fake-data/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
/home/runner/work/fake-data/fake-data/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
```